### PR TITLE
Add onboarding pages and notifications bell

### DIFF
--- a/apps/web/components/common/HiveIcon.tsx
+++ b/apps/web/components/common/HiveIcon.tsx
@@ -1,9 +1,20 @@
+import classNames from 'classnames';
+import { ColorKey } from 'hive-lib';
 import { SVGProps } from 'react';
 import { HexPath } from './HexPath';
 
-const HiveIcon = (props: SVGProps<SVGSVGElement>) => {
+interface HiveIconProps extends SVGProps<SVGSVGElement> {
+  hexColor?: ColorKey;
+}
+
+const HiveIcon = (props: HiveIconProps) => {
+  const { className, hexColor, ...rest } = props;
+  const cn = classNames(className, {
+    'stroke-hiveblack fill-hivewhite': hexColor === 'w',
+    'stroke-hiveblack fill-hiveblack': hexColor === 'b'
+  });
   return (
-    <svg viewBox='-12 -12 24 24' {...props}>
+    <svg className={cn} viewBox='-12 -12 24 24' {...rest}>
       <HexPath />
     </svg>
   );

--- a/apps/web/components/forms/FinishProfileForm.tsx
+++ b/apps/web/components/forms/FinishProfileForm.tsx
@@ -1,0 +1,114 @@
+import * as Yup from 'yup';
+import {
+  Form,
+  Formik,
+  FormikHelpers,
+  useField,
+  useFormikContext
+} from 'formik';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Input,
+  Stack
+} from '@chakra-ui/react';
+import { useRouter } from 'next/router';
+import { updateUsername, getUsernameAvailable } from 'hive-db';
+
+interface UsernameFormValues {
+  username: string;
+}
+
+const usernameValidationSchema = Yup.object({
+  username: Yup.string()
+    .min(3, 'Username must be at least 3 characters')
+    .max(20, 'Username must be 20 characters or less')
+    .required('Required')
+});
+
+const UsernameInput = ({
+  label,
+  placeholder
+}: {
+  label: string;
+  placeholder?: string;
+}) => {
+  const [field, meta] = useField('username');
+  const { isSubmitting } = useFormikContext();
+  return (
+    <FormControl
+      isDisabled={isSubmitting}
+      isInvalid={meta.touched && !!meta.error}
+    >
+      <FormLabel htmlFor={field.name}>{label}</FormLabel>
+      <Input
+        {...field}
+        id={field.name}
+        bg='white'
+        placeholder={placeholder || 'Username'}
+      />
+      {meta.touched && meta.error && (
+        <FormErrorMessage>{meta.error}</FormErrorMessage>
+      )}
+    </FormControl>
+  );
+};
+
+const SubmitButton = () => {
+  const { isSubmitting } = useFormikContext();
+  return (
+    <Button
+      isLoading={isSubmitting}
+      isDisabled={isSubmitting}
+      type='submit'
+      colorScheme='teal'
+    >
+      Submit
+    </Button>
+  );
+};
+
+const FinishProfileForm = ({ uid }: { uid: string }) => {
+  const initialValues: UsernameFormValues = { username: '' };
+  const router = useRouter();
+  const handleSubmit = (
+    values: UsernameFormValues,
+    helpers: FormikHelpers<UsernameFormValues>
+  ) => {
+    helpers.setSubmitting(true);
+    getUsernameAvailable(values.username)
+      .then((available) => {
+        if (available) {
+          updateUsername(uid, values.username).then(() => router.push('/'));
+        } else {
+          helpers.setSubmitting(false);
+          helpers.setFieldError('username', 'Username is taken');
+        }
+      })
+      .catch((err) => {
+        helpers.setSubmitting(false);
+        helpers.setFieldError('username', 'Error checking username');
+      });
+  };
+  return (
+    <Formik
+      initialValues={initialValues}
+      validationSchema={usernameValidationSchema}
+      onSubmit={handleSubmit}
+    >
+      <Form>
+        <Stack>
+          <UsernameInput label='Pick a username to finish setting up your profile:' />
+          <Box>
+            <SubmitButton />
+          </Box>
+        </Stack>
+      </Form>
+    </Formik>
+  );
+};
+
+export { FinishProfileForm };

--- a/apps/web/components/forms/SignUpEmailForm.tsx
+++ b/apps/web/components/forms/SignUpEmailForm.tsx
@@ -1,0 +1,126 @@
+import { Form, Formik, Field } from 'formik';
+import * as Yup from 'yup';
+import { parseAuthError, usePlayer } from 'hive-db';
+import {
+  Button,
+  FormControl,
+  FormErrorMessage,
+  Input,
+  useToast,
+  VStack
+} from '@chakra-ui/react';
+
+interface SignUpEmailFormProps {
+  setPending: (isPending: boolean) => void;
+  onSuccess: () => void;
+  disabled?: boolean;
+}
+
+const validationSchema = Yup.object({
+  email: Yup.string()
+    .email('Invalid email address')
+    .required('Email address is required'),
+  password: Yup.string()
+    .min(6, 'Password must be at least 6 characters long')
+    .required('Password is required'),
+  passwordConfirm: Yup.string().oneOf(
+    [Yup.ref('password'), null],
+    'Passwords must match'
+  )
+});
+
+const initialValues = { email: '', password: '', passwordConfirm: '' };
+
+const SignUpEmailForm = (props: SignUpEmailFormProps) => {
+  const { setPending, disabled, onSuccess } = props;
+  const { signUpWithEmail } = usePlayer();
+
+  const toast = useToast();
+
+  const onSubmit = ({
+    email,
+    password
+  }: {
+    email: string;
+    password: string;
+  }) => {
+    setPending(true);
+    signUpWithEmail(email, password)
+      .then(onSuccess)
+      .catch((error) => {
+        setPending(false);
+        toast({
+          title: 'Error',
+          description: parseAuthError(error),
+          status: 'error',
+          duration: 9000,
+          isClosable: true
+        });
+      });
+  };
+
+  return (
+    <Formik
+      initialValues={initialValues}
+      validationSchema={validationSchema}
+      onSubmit={onSubmit}
+    >
+      <Form>
+        <VStack spacing={2} width='full'>
+          <Field name='email'>
+            {({ field, form }: any) => (
+              <FormControl
+                isDisabled={disabled}
+                isInvalid={form.errors.email && form.touched.email}
+              >
+                <Input {...field} id='email' placeholder='Email' />
+                <FormErrorMessage>{form.errors.email}</FormErrorMessage>
+              </FormControl>
+            )}
+          </Field>
+          <Field name='password'>
+            {({ field, form }: any) => (
+              <FormControl
+                isDisabled={props.disabled}
+                isInvalid={form.errors.password && form.touched.password}
+              >
+                <Input
+                  {...field}
+                  id='password'
+                  placeholder='Password'
+                  type='password'
+                />
+                <FormErrorMessage>{form.errors.password}</FormErrorMessage>
+              </FormControl>
+            )}
+          </Field>
+          <Field name='passwordConfirm'>
+            {({ field, form }: any) => (
+              <FormControl
+                isDisabled={props.disabled}
+                isInvalid={
+                  form.errors.passwordConfirm && form.touched.passwordConfirm
+                }
+              >
+                <Input
+                  {...field}
+                  id='passwordConfirm'
+                  placeholder='Confirm Password'
+                  type='password'
+                />
+                <FormErrorMessage>
+                  {form.errors.passwordConfirm}
+                </FormErrorMessage>
+              </FormControl>
+            )}
+          </Field>
+          <Button isDisabled={disabled} type='submit' width='100%'>
+            Sign Up
+          </Button>
+        </VStack>
+      </Form>
+    </Formik>
+  );
+};
+
+export { SignUpEmailForm };

--- a/apps/web/components/forms/SignUpForm.tsx
+++ b/apps/web/components/forms/SignUpForm.tsx
@@ -1,0 +1,56 @@
+import { useToast } from '@chakra-ui/react';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+import { GoogleButton } from './GoogleButton';
+import { SignUpEmailForm } from './SignUpEmailForm';
+
+const SignUpForm = () => {
+  const router = useRouter();
+  const [isPending, setPending] = useState(false);
+  const toast = useToast();
+
+  const errorToast = (message: string) => {
+    toast({
+      title: 'Error',
+      description: message,
+      status: 'error',
+      duration: 9000,
+      isClosable: true
+    });
+  };
+
+  const onPending = () => {
+    setPending(true);
+  };
+
+  const onSuccess = () => {
+    router.push('/profile');
+  };
+
+  return (
+    <div className='divide-y divide-dashed'>
+      <div className='pb-4'>
+        <GoogleButton
+          onPending={onPending}
+          onFailure={() => {
+            setPending(false);
+            errorToast('Unable to sign up with Google');
+          }}
+          disabled={isPending}
+          onSuccess={onSuccess}
+        >
+          Sign up with Google
+        </GoogleButton>
+      </div>
+      <div className='pt-4'>
+        <SignUpEmailForm
+          setPending={setPending}
+          disabled={isPending}
+          onSuccess={onSuccess}
+        />
+      </div>
+    </div>
+  );
+};
+
+export { SignUpForm };

--- a/apps/web/components/nav/NavBar.tsx
+++ b/apps/web/components/nav/NavBar.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { NavLink } from '../common/NavLink';
 import { FinishProfileLinks } from './FinishProfileLinks';
 import { HiveLogoLink } from './HiveLogoLink';
+import { NotificationsBell } from './NotificationsBell';
 import { SignInLink } from './SignInLink';
 import { Spinner } from './Spinner';
 import { Username } from './Username';
@@ -51,6 +52,7 @@ const NavBar = (props: NavBarProps) => {
           </>
         )}
       </div>
+      {user && <NotificationsBell />}
       <NavBarUsername />
     </Nav>
   );

--- a/apps/web/components/nav/NotificationsBell.tsx
+++ b/apps/web/components/nav/NotificationsBell.tsx
@@ -1,0 +1,127 @@
+import {
+  forwardRef,
+  Menu,
+  MenuButton,
+  MenuGroup,
+  MenuGroupProps,
+  MenuItem,
+  MenuItemProps,
+  MenuList
+} from '@chakra-ui/react';
+import { useRouter } from 'next/router';
+import { useCallback, useMemo } from 'react';
+import { BsBell } from 'react-icons/bs';
+import {
+  isTurnNotification,
+  TurnNotification
+} from '../../contexts/notifications/notification';
+import { useNotifications } from '../../contexts/notifications/NotificationProvider';
+import { useHasMounted } from '../../hooks/useHasMounted';
+import { HiveIcon } from '../common/HiveIcon';
+import { NavText } from '../common/NavText';
+
+const BellIdle = () => {
+  return (
+    <NavText className='relative'>
+      <BsBell className='fill-slate-300' />
+    </NavText>
+  );
+};
+
+const BellActive = () => {
+  return (
+    <NavText className='relative'>
+      <BsBell className='fill-hive' />
+    </NavText>
+  );
+};
+
+const BellNew = () => {
+  return (
+    <NavText className='relative'>
+      <BsBell className='fill-hive' />
+      <span className='animate-pulse absolute top-0 right-0 inline-block w-2 h-2 transform -translate-x-1/2 -translate-y-1/2 bg-hive rounded-full' />
+    </NavText>
+  );
+};
+
+const Bell = () => {
+  const { notifications, unread } = useNotifications();
+  if (!notifications.length) return <BellIdle />;
+  return unread > 0 ? <BellNew /> : <BellActive />;
+};
+
+interface TurnItemProps extends MenuItemProps {
+  notification: TurnNotification;
+}
+
+const TurnItem = forwardRef<TurnItemProps, any>((props, ref) => {
+  const { notification, ...rest } = props;
+  const { gid, opponent, opponentColor } = notification;
+  const router = useRouter();
+
+  const onClick = () => router.push(`/game/${gid}`);
+
+  return (
+    <MenuItem
+      ref={ref}
+      onClick={onClick}
+      className='prose text-sm'
+      icon={<HiveIcon hexColor={opponentColor} width={14} height={14} />}
+      {...rest}
+    >
+      {opponent}
+    </MenuItem>
+  );
+});
+
+interface TurnGroupProps extends MenuGroupProps {
+  notifications: TurnNotification[];
+}
+
+const TurnGroup = forwardRef<TurnGroupProps, any>((props, ref) => {
+  const { notifications, ...rest } = props;
+  return (
+    <MenuGroup ref={ref} title={`It's your turn against:`} {...rest}>
+      {notifications.map((n) => (
+        <TurnItem key={n.gid} notification={n} />
+      ))}
+    </MenuGroup>
+  );
+});
+
+const NotificationsBell = () => {
+  const { notifications, markRead } = useNotifications();
+  const mounted = useHasMounted();
+
+  // Separate the notifications out into their types
+  const turnNotifications = useMemo(() => {
+    return notifications.filter(isTurnNotification);
+  }, [notifications]);
+
+  // When the user opens the menu, they'll have seen all of the notifications
+  // so create a callback to mark them all as read
+  const onOpen = useCallback(
+    () => markRead(notifications),
+    [markRead, notifications]
+  );
+
+  // For SSG, just render the idle bell
+  if (!mounted) {
+    return <BellIdle />;
+  }
+
+  // Otherwise render the fully functional bell
+  return (
+    <Menu onOpen={onOpen}>
+      <MenuButton disabled={notifications.length === 0}>
+        <Bell />
+      </MenuButton>
+      <MenuList>
+        <TurnGroup notifications={turnNotifications} />
+      </MenuList>
+    </Menu>
+  );
+};
+
+export { NotificationsBell };

--- a/apps/web/contexts/notifications/NotificationProvider.tsx
+++ b/apps/web/contexts/notifications/NotificationProvider.tsx
@@ -1,0 +1,60 @@
+import { usePlayer } from 'hive-db';
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useReducer
+} from 'react';
+import { initialState, notificationReducer } from './notificationReducer';
+import { Notification } from './notification';
+
+export interface NotificationsContextProps {
+  notifications: Notification[];
+  unread: number;
+  markRead: (notifications: Notification[]) => void;
+}
+
+const notificationsContext = createContext<NotificationsContextProps>(
+  defaultNotificationsContext()
+);
+
+const NotificationProvider = ({ children }: { children?: ReactNode }) => {
+  const notificationsState = useNotificationsState();
+  return (
+    <notificationsContext.Provider value={notificationsState}>
+      {children}
+    </notificationsContext.Provider>
+  );
+};
+
+const useNotifications = () => {
+  return useContext(notificationsContext);
+};
+
+function useNotificationsState(): NotificationsContextProps {
+  const { uid, activeGames } = usePlayer();
+  const [state, dispatch] = useReducer(notificationReducer, initialState());
+
+  useEffect(() => {
+    dispatch({ type: 'games', data: { uid, games: activeGames } });
+  }, [uid, activeGames]);
+
+  return {
+    notifications: state.notifications,
+    unread: state.unread,
+    markRead: (notifications: Notification[]) => {
+      dispatch({ type: 'mark-read', notifications });
+    }
+  };
+}
+
+function defaultNotificationsContext(): NotificationsContextProps {
+  return {
+    notifications: [],
+    unread: 0,
+    markRead: (_) => {}
+  };
+}
+
+export { NotificationProvider, useNotifications };

--- a/apps/web/contexts/notifications/README.md
+++ b/apps/web/contexts/notifications/README.md
@@ -1,0 +1,41 @@
+# Notification Provider
+
+This is a React context provider that allows you to interact with lihive
+notifications from anywhere within the app.
+
+Wrap the app in the context provider (in `_app.tsx`):
+
+```tsx
+function App() {
+  return <NotificationProvider>
+    {...}
+  </NotificationProvider>
+}
+```
+
+Use the `useNotifications()` hook to retrieve the current notifications and
+related functionality:
+
+```tsx
+const { 
+  notifications, // an array of Notification object
+  unread,        // the number of notifications NOT marked as read
+  markRead       // a callback you can use to mark notifications as read
+} = useNotifications();
+
+// the markRead callback accepts an array of notification ids to mark as read so
+// here we create a callback to mark all notifications as read
+const markAllRead = () => {
+  markRead(notifications.map(n => n.id));
+}
+
+// render the notifications
+return <List>
+  {notifications.map(n => (<Item>{...}</Item>))}
+</List>
+
+// or let the user mark them as read
+return <Button onClick={markAllRead}/>
+
+// or whatever else you'd like to do!
+```

--- a/apps/web/contexts/notifications/notification.ts
+++ b/apps/web/contexts/notifications/notification.ts
@@ -1,0 +1,61 @@
+import { Game, getOpponentColor, getOpponentUsername } from 'hive-db';
+import { ColorKey } from 'hive-lib';
+
+export interface InviteNotification {
+  type: 'invite';
+  id: string;
+  read: boolean;
+  gid: string;
+  opponent: string;
+}
+
+export interface TurnNotification {
+  type: 'turn';
+  id: string;
+  read: boolean;
+  gid: string;
+  opponent: string;
+  opponentColor: ColorKey;
+}
+
+export type Notification = TurnNotification | InviteNotification;
+
+function inviteNotification(uid: string, game: Game): InviteNotification {
+  const { gid } = game;
+  const opponent = getOpponentUsername(game, uid);
+  return {
+    type: 'invite',
+    id: gid,
+    read: false,
+    gid,
+    opponent
+  };
+}
+
+function isInviteNotification(
+  notification: Notification
+): notification is InviteNotification {
+  return notification.type === 'invite';
+}
+
+function turnNotification(uid: string, game: Game): TurnNotification {
+  const { gid } = game;
+  const opponent = getOpponentUsername(game, uid);
+  const opponentColor = getOpponentColor(game, uid);
+  return {
+    type: 'turn',
+    id: gid,
+    read: false,
+    gid,
+    opponent,
+    opponentColor
+  };
+}
+
+function isTurnNotification(
+  notification: Notification
+): notification is TurnNotification {
+  return notification.type === 'turn';
+}
+
+export { turnNotification, isTurnNotification };

--- a/apps/web/contexts/notifications/notificationReducer.ts
+++ b/apps/web/contexts/notifications/notificationReducer.ts
@@ -1,0 +1,95 @@
+import { Game, getTurnUid } from 'hive-db';
+import { keyBy } from 'lodash';
+import { turnNotification, Notification } from './notification';
+
+interface State {
+  uid: string | null;
+  notifications: Notification[];
+  unread: number;
+}
+
+type ActionGames = { type: 'games'; data: { uid: string; games: Game[] } };
+type ActionRead = { type: 'mark-read'; notifications: Notification[] };
+type Action = ActionGames | ActionRead;
+
+function initialState(): State {
+  return {
+    uid: null,
+    notifications: [],
+    unread: 0
+  };
+}
+
+function notificationReducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'games':
+      return handleGames(state, action);
+    case 'mark-read':
+      return handleMarkRead(state, action);
+  }
+  return state;
+}
+
+function handleGames(state: State, action: ActionGames): State {
+  const { uid, games } = action.data;
+
+  // if the user is signed out then there cannot be any notifications
+  if (uid === null) {
+    return initialState();
+  }
+
+  // if the user changes, start with any empty list of notifications, otherwise
+  // use existing notifications
+  const notifications = uid !== state.uid ? [] : state.notifications;
+
+  // get the games where it's the user's turn and map games by their ids
+  const turnGames = games.filter((g) => getTurnUid(g) === uid);
+  const byId = keyBy(turnGames, (g) => g.gid);
+
+  // get the ids of games we already have notifications for and of all current games
+  const existingIds = new Set(notifications.map((n) => n.id));
+  const allIds = new Set(turnGames.map((g) => g.gid));
+
+  // create a list of notifications to add and of ones to remove
+  const toAdd = setDifference(allIds, existingIds);
+  const toRemove = setDifference(existingIds, allIds);
+
+  // create the new list of notifications
+  const newNotifications = [
+    ...Array.from(toAdd).map((gid) => turnNotification(uid, byId[gid])),
+    ...notifications.filter((n) => !toRemove.has(n.id))
+  ];
+
+  // count how many are unread
+  const unread = newNotifications.filter((n) => !n.read).length;
+
+  return {
+    uid,
+    unread,
+    notifications: newNotifications
+  };
+}
+
+function handleMarkRead(state: State, action: ActionRead): State {
+  const ids = new Set(action.notifications.map((n) => n.id));
+  const notifications = state.notifications.map((n) => {
+    return ids.has(n.id) ? { ...n, read: true } : n;
+  });
+  const unread = notifications.filter((n) => !n.read).length;
+  return {
+    ...state,
+    notifications,
+    unread
+  };
+}
+
+/**
+ * Compute the set difference {a} - {b}
+ */
+function setDifference<T>(a: Set<T>, b: Set<T>): Set<T> {
+  const diff = new Set(a);
+  b.forEach((el) => diff.delete(el));
+  return diff;
+}
+
+export { notificationReducer, initialState };

--- a/apps/web/hooks/useHasMounted.ts
+++ b/apps/web/hooks/useHasMounted.ts
@@ -1,0 +1,11 @@
+import { useEffect, useState } from 'react';
+
+function useHasMounted() {
+  const [hasMounted, setHasMounted] = useState(false);
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
+  return hasMounted;
+}
+
+export { useHasMounted };

--- a/apps/web/hooks/useTitle.ts
+++ b/apps/web/hooks/useTitle.ts
@@ -1,0 +1,10 @@
+import { useNotifications } from '../contexts/notifications/NotificationProvider';
+
+function useTitle() {
+  const { unread } = useNotifications();
+  return unread === 0
+    ? `lihive.org • Free Online Hive`
+    : `(${unread}) lihive.org • Free Online Hive`;
+}
+
+export { useTitle };

--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -5,6 +5,7 @@ import { ChakraProvider } from '@chakra-ui/react';
 import { Global, css } from '@emotion/react';
 import { AppProps } from 'next/app';
 import { PlayerProvider } from 'hive-db';
+import { NotificationProvider } from '../contexts/notifications/NotificationProvider';
 import { theme } from '../styles/theme';
 
 const GlobalStyle = () => {
@@ -31,8 +32,10 @@ function App({ Component, pageProps }: AppProps) {
   return (
     <ChakraProvider theme={theme}>
       <PlayerProvider>
-        <GlobalStyle />
-        <Component {...pageProps} />
+        <NotificationProvider>
+          <GlobalStyle />
+          <Component {...pageProps} />
+        </NotificationProvider>
       </PlayerProvider>
     </ChakraProvider>
   );

--- a/apps/web/pages/community.tsx
+++ b/apps/web/pages/community.tsx
@@ -7,10 +7,12 @@ import { ListPublicGames } from '../components/lists/ListPublicGames';
 import { ListUsers } from '../components/lists/ListUsers';
 import { NavBar } from '../components/nav/NavBar';
 import Head from 'next/head';
+import { useTitle } from '../hooks/useTitle';
 
 const Community = () => {
   const { uid, incompleteProfile } = usePlayer();
   const [users, setUsers] = useState<UserData[]>([]);
+  const title = useTitle();
   const router = useRouter();
 
   useEffect(() => {
@@ -21,7 +23,7 @@ const Community = () => {
   return (
     <>
       <Head>
-        <title>lihive.org • Free Online Hive</title>
+        <title>{title}</title>
       </Head>
       <NavBar />
       <Body className='my-12'>

--- a/apps/web/pages/games.tsx
+++ b/apps/web/pages/games.tsx
@@ -8,6 +8,7 @@ import { ListPlayerCompleted } from '../components/lists/ListPlayerCompleted';
 import { ListPlayerGames } from '../components/lists/ListPlayerGames';
 import { ListPlayerInvitations } from '../components/lists/ListPlayerInvitations';
 import { NavBar } from '../components/nav/NavBar';
+import { useTitle } from '../hooks/useTitle';
 
 const None = () => {
   return <div className='px-8 py-4 prose'>None yet.</div>;
@@ -16,6 +17,7 @@ const None = () => {
 const Games = () => {
   const { uid, incompleteProfile, activeGames, completedGames, invitations } =
     usePlayer();
+  const title = useTitle();
   const router = useRouter();
 
   useEffect(() => {
@@ -29,7 +31,7 @@ const Games = () => {
   return (
     <>
       <Head>
-        <title>lihive.org • Free Online Hive</title>
+        <title>{title}</title>
       </Head>
       <NavBar />
       <Body className='my-12'>

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -18,6 +18,8 @@ import { ListPlayerGames } from '../components/lists/ListPlayerGames';
 import { ListPublicGames } from '../components/lists/ListPublicGames';
 import { NavBar } from '../components/nav/NavBar';
 import Head from 'next/head';
+import { useHasMounted } from '../hooks/useHasMounted';
+import { useTitle } from '../hooks/useTitle';
 
 const IndexTabs = () => {
   const { uid, incompleteProfile, activeGames } = usePlayer();
@@ -54,12 +56,14 @@ const IndexTabs = () => {
 
 const Index = () => {
   const { uid, incompleteProfile } = usePlayer();
+  const title = useTitle();
   const router = useRouter();
-  const loggedIn = !!uid && !incompleteProfile;
+  const mounted = useHasMounted();
+  const loggedIn = mounted && !!uid && !incompleteProfile;
   return (
     <>
       <Head>
-        <title>lihive.org • Free Online Hive</title>
+        <title>{title}</title>
       </Head>
       <NavBar />
       <div className='bg-slate-50 mb-16'>
@@ -105,14 +109,6 @@ const Index = () => {
               >
                 Create New Game
               </Button>
-              {/*<Button*/}
-              {/*  leftIcon={<Icon as={FaDiscord} w={5} h={5} />}*/}
-              {/*  iconSpacing={3}*/}
-              {/*  colorScheme='teal'*/}
-              {/*  size='md'*/}
-              {/*>*/}
-              {/*  Chat With Friends*/}
-              {/*</Button>*/}
               <Button
                 leftIcon={<Icon as={FaGamepad} w={5} h={5} />}
                 iconSpacing={3}

--- a/apps/web/pages/profile.tsx
+++ b/apps/web/pages/profile.tsx
@@ -1,0 +1,31 @@
+import { usePlayer } from 'hive-db';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+import { useTitle } from '../hooks/useTitle';
+import { NavBar } from '../components/nav/NavBar';
+import { FinishProfileForm } from '../components/forms/FinishProfileForm';
+import Head from 'next/head';
+
+const Profile = () => {
+  const { uid, incompleteProfile } = usePlayer();
+  const title = useTitle();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!incompleteProfile) router.push('/');
+  }, [incompleteProfile, router]);
+
+  return (
+    <>
+      <Head>
+        <title>{title}</title>
+      </Head>
+      <NavBar hideFinishProfile />
+      <div className='prose mx-auto my-16'>
+        {uid && incompleteProfile && <FinishProfileForm uid={uid} />}
+      </div>
+    </>
+  );
+};
+
+export default Profile;

--- a/apps/web/pages/register.tsx
+++ b/apps/web/pages/register.tsx
@@ -1,0 +1,29 @@
+import { usePlayer } from 'hive-db';
+import { useRouter } from 'next/router';
+import { SignUpForm } from '../components/forms/SignUpForm';
+import { NavBar } from '../components/nav/NavBar';
+import { useTitle } from '../hooks/useTitle';
+import Head from 'next/head';
+
+const Register = () => {
+  const { uid, incompleteProfile } = usePlayer();
+  const router = useRouter();
+  const title = useTitle();
+
+  if (uid !== null && incompleteProfile) router.push('/profile');
+  if (uid !== null && !incompleteProfile) router.push('/');
+
+  return (
+    <>
+      <Head>
+        <title>{title}</title>
+      </Head>
+      <NavBar />
+      <div className='prose mx-auto my-16'>
+        <SignUpForm />
+      </div>
+    </>
+  );
+};
+
+export default Register;


### PR DESCRIPTION
This PR adds the onboarding pages, which I forgot when migrating from the old repo, as well as a bell icon next to the username in the navbar that provides a simple notifications menu. The menu shows a list of games where it is the user's turn. Also the page title is updated with the number of unread notifications.